### PR TITLE
Fix issue with url column too short

### DIFF
--- a/app/Repos/HackerNews/Utils.php
+++ b/app/Repos/HackerNews/Utils.php
@@ -68,7 +68,14 @@ class Utils
                 try {
                     $hackerNewsItem->save();
                 } catch (Exception $exception) {
-                    Log::error("Could not save story to DB", [print_r($story, true)]);
+                    Log::error(
+                        "Could not save story to DB",
+                        [
+                            'exceptionMessage' => $exception->getMessage(),
+                            'data' => print_r($story, true),
+                        ]
+                    );
+
                 }
             })
             ->count();

--- a/database/migrations/2019_06_13_132027_increase_url_field_length_for_hacker_news_items_table.php
+++ b/database/migrations/2019_06_13_132027_increase_url_field_length_for_hacker_news_items_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class IncreaseUrlFieldLengthForHackerNewsItemsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('hacker_news_items', function (Blueprint $table) {
+            $table->string('url', 2000)->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('hacker_news_items', function (Blueprint $table) {
+            $table->string('url', 1000)->change();
+        });
+    }
+}


### PR DESCRIPTION
On hacker_news_items table, the column url is too short
causing some imports to fail.
Closes #88