### PR TITLE
Fix issue with queue worker status

### DIFF
--- a/app/Libraries/SysInfo/SysInfo.php
+++ b/app/Libraries/SysInfo/SysInfo.php
@@ -103,7 +103,7 @@ class SysInfo
      */
     public function nQueueWorkersRunning(): int
     {
-        $command = "ps aux | grep 'php artisan queue:work' | grep -v 'grep' | awk '{print $2}'";
+        $command = "ps aux | grep 'php artisan queue:work' | grep -v 'grep' | grep -v 'runuser' | awk '{print $2}'";
         try {
             exec($command, $output);
         } catch (Exception $exception) {


### PR DESCRIPTION
The number of queue workers was incorrectly identified with
the command that was being used. The command was not ignoring
the `runuser` command.
Closes #264