### PR TITLE
Add missing tests for new API routes

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -140,7 +140,6 @@ Auth::routes(['register' => false]);
 Route::get('/home', [HomeController::class, 'index'])
     ->name('home');
 
-// move to api namespace
 Route::get('/api/inspire', [InspireController::class, 'index']);
 Route::get('/api/system-info', [SystemInfoController::class, 'index']);
 Route::get('/api/next-holidays', [NextHolidaysController::class, 'index']);

--- a/tests/Feature/Controllers/Api/ApiCommonTest.php
+++ b/tests/Feature/Controllers/Api/ApiCommonTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Tests\Feature\Controllers\Api;
+
+use App\Models\User;
+use Tests\TestCase;
+
+class ApiCommonTest extends TestCase
+{
+    public function testMakeCommonApiRequestsWithNoAuth()
+    {
+        $this
+            ->get('/api/inspire')
+            ->assertStatus(302)
+        ;
+
+        $this
+            ->get('/api/next-holidays')
+            ->assertStatus(302)
+        ;
+
+        $this
+            ->get('/api/system-info')
+            ->assertStatus(302)
+        ;
+
+        $this
+            ->get('/api/remote-jobs')
+            ->assertStatus(302)
+        ;
+    }
+
+    public function testMakeCommonApiRequests()
+    {
+        $user = factory(User::class)
+            ->create();
+
+        $this
+            ->actingAs($user)
+            ->get('/api/inspire')
+            ->assertStatus(200)
+            ->assertJsonStructure([
+                'data',
+            ])
+        ;
+
+        $this
+            ->actingAs($user)
+            ->get('/api/next-holidays')
+            ->assertStatus(200)
+            ->assertJsonStructure([
+                'data',
+            ])
+        ;
+
+        $this
+            ->actingAs($user)
+            ->get('/api/system-info')
+            ->assertStatus(200)
+            ->assertJsonStructure([
+                'data',
+            ])
+        ;
+
+        $this
+            ->actingAs($user)
+            ->get('/api/remote-jobs')
+            ->assertStatus(200)
+            ->assertJsonStructure([
+                'data',
+            ])
+        ;
+    }
+}


### PR DESCRIPTION
Related to #398, #399, #400, and #401.